### PR TITLE
ci: use ubuntu 20.04

### DIFF
--- a/.github/workflows/docker_publish.yaml
+++ b/.github/workflows/docker_publish.yaml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.event_name == 'push'
 
     steps:


### PR DESCRIPTION
## Changed
- Use ubuntu 20.04 in the `build` workflow (`main` + tags)